### PR TITLE
fixing the toc so that tools spans to the end of the third row

### DIFF
--- a/_includes/_sass/includes/_table-of-contents.scss
+++ b/_includes/_sass/includes/_table-of-contents.scss
@@ -38,7 +38,7 @@
 
 	.col--tools {
 		@include breakpoint($breakpoint-bravo) {
-			grid-area: 1 / 4 / 3;
+			grid-area: 1 / 4 / 4;
 		}
 	}
 


### PR DESCRIPTION
## Description
Fixing the TOC layout so that tools spans to the beginning of the fourth column.


Just a little :bug: fix.